### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     },
     "license": "MIT",
     "engines": {
-        "vscode": "^1.97.0"
+        "vscode": "^1.96.0"
     },
     "categories": [
         "Themes"


### PR DESCRIPTION
change vscode engine to 1.96.0 to allow this extension to be used on cursor.

![image](https://github.com/user-attachments/assets/78212e8d-2e2c-4b6b-8fc4-800672d849c4)

this is what happens when I try to use this theme on cursor, it's not allowing the vscode engine cursor is using.

I don't know if this affects any functionality, but I would be nice to have it on cursor.

nice theme, I like it, thanks for your effort on making it.